### PR TITLE
Fix navigation and API helper

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -13,28 +13,44 @@ import Settings from "@/pages/Settings";
 import ShortsGenerator from "@/pages/ShortsGenerator";
 import Engagement from "@/pages/Engagement";
 import Billing from "@/pages/Billing";
+import UploadPage from "@/pages/Upload";
+import LibraryPage from "@/pages/Library";
+import AccountsPage from "@/pages/Accounts";
 import NotFound from "@/pages/not-found";
 
 function Router() {
   const { isAuthenticated, isLoading } = useAuth();
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        Loading...
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return (
+      <Switch>
+        <Route path="/" component={Landing} />
+        <Route component={NotFound} />
+      </Switch>
+    );
+  }
 
   return (
     <Switch>
-      {isLoading || !isAuthenticated ? (
-        <Route path="/" component={Landing} />
-      ) : (
-        <>
-          <Route path="/" component={Dashboard} />
-          <Route path="/dashboard" component={Dashboard} />
-          <Route path="/scheduling" component={Scheduling} />
-          <Route path="/analytics" component={Analytics} />
-          <Route path="/monetization" component={Monetization} />
-          <Route path="/engagement" component={Engagement} />
-          <Route path="/shorts" component={ShortsGenerator} />
-          <Route path="/billing" component={Billing} />
-          <Route path="/settings" component={Settings} />
-        </>
-      )}
+      <Route path="/" component={Dashboard} />
+      <Route path="/dashboard" component={Dashboard} />
+      <Route path="/upload" component={UploadPage} />
+      <Route path="/library" component={LibraryPage} />
+      <Route path="/accounts" component={AccountsPage} />
+      <Route path="/scheduling" component={Scheduling} />
+      <Route path="/analytics" component={Analytics} />
+      <Route path="/monetization" component={Monetization} />
+      <Route path="/engagement" component={Engagement} />
+      <Route path="/shorts" component={ShortsGenerator} />
+      <Route path="/billing" component={Billing} />
+      <Route path="/settings" component={Settings} />
       <Route component={NotFound} />
     </Switch>
   );

--- a/client/src/components/SchedulingCalendar.tsx
+++ b/client/src/components/SchedulingCalendar.tsx
@@ -283,6 +283,7 @@ export default function SchedulingCalendar({ uploadId }: SchedulingCalendarProps
                     <SelectItem value="linkedin">LinkedIn</SelectItem>
                     <SelectItem value="instagram">Instagram</SelectItem>
                     <SelectItem value="tiktok">TikTok</SelectItem>
+                    <SelectItem value="youtube">YouTube</SelectItem>
                   </SelectContent>
                 </Select>
               </div>
@@ -299,18 +300,11 @@ export default function SchedulingCalendar({ uploadId }: SchedulingCalendarProps
 
             <div>
               <Label htmlFor="time">Time</Label>
-              <Select value={scheduledTime} onValueChange={setScheduledTime}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {generateOptimalTimes().map((timeOption) => (
-                    <SelectItem key={timeOption.time} value={timeOption.time}>
-                      {timeOption.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Input
+                type="time"
+                value={scheduledTime}
+                onChange={(e) => setScheduledTime(e.target.value)}
+              />
             </div>
 
             {!selectedPost && (

--- a/client/src/components/Sidebar.tsx
+++ b/client/src/components/Sidebar.tsx
@@ -50,14 +50,14 @@ export default function Sidebar() {
         {navigationItems.map((item) => {
           const Icon = item.icon;
           return (
-            <a
+            <Link
               key={item.label}
               href={item.href}
               className={`sidebar-nav-item ${item.active ? 'active' : ''}`}
             >
               <Icon className="w-5 h-5 mr-3" />
               {item.label}
-            </a>
+            </Link>
           );
         })}
       </nav>

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -8,16 +8,32 @@ async function throwIfResNotOk(res: Response) {
 }
 
 export async function apiRequest(
-  method: string,
-  url: string,
-  data?: unknown | undefined,
+  arg1: string,
+  arg2: string | RequestInit,
+  arg3?: unknown,
 ): Promise<Response> {
-  const res = await fetch(url, {
-    method,
-    headers: data ? { "Content-Type": "application/json" } : {},
-    body: data ? JSON.stringify(data) : undefined,
-    credentials: "include",
-  });
+  let url: string;
+  let init: RequestInit = { credentials: "include" };
+
+  if (typeof arg2 === "object" && !(typeof arg2 === "string")) {
+    // apiRequest(url, fetchOptions)
+    url = arg1;
+    init = { ...init, ...arg2 };
+  } else {
+    // apiRequest(method, url, data) or apiRequest(url, method, data)
+    const isUrlFirst = arg1.startsWith("/") || arg1.startsWith("http");
+    const method = isUrlFirst ? (arg2 as string) : arg1;
+    url = isUrlFirst ? arg1 : (arg2 as string);
+    const data = arg3;
+    init = {
+      ...init,
+      method,
+      headers: data ? { "Content-Type": "application/json" } : undefined,
+      body: data ? JSON.stringify(data) : undefined,
+    };
+  }
+
+  const res = await fetch(url, init);
 
   await throwIfResNotOk(res);
   return res;

--- a/client/src/pages/Accounts.tsx
+++ b/client/src/pages/Accounts.tsx
@@ -1,0 +1,15 @@
+import Sidebar from "@/components/Sidebar";
+import { Navigation } from "@/components/Navigation";
+import SocialAccountsManager from "@/components/SocialAccountsManager";
+
+export default function AccountsPage() {
+  return (
+    <div className="flex h-screen overflow-hidden bg-slate-50">
+      <Sidebar />
+      <div className="flex-1 overflow-y-auto p-6 space-y-6">
+        <Navigation title="Social Accounts" />
+        <SocialAccountsManager />
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Library.tsx
+++ b/client/src/pages/Library.tsx
@@ -1,0 +1,17 @@
+import RecentContent from "@/components/RecentContent";
+import Sidebar from "@/components/Sidebar";
+import { Navigation } from "@/components/Navigation";
+
+export default function LibraryPage() {
+  return (
+    <div className="flex h-screen overflow-hidden bg-slate-50">
+      <Sidebar />
+      <div className="flex-1 overflow-y-auto p-6">
+        <Navigation title="Content Library" />
+        <div className="mt-6">
+          <RecentContent />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/Upload.tsx
+++ b/client/src/pages/Upload.tsx
@@ -1,0 +1,19 @@
+import UploadSection from "@/components/UploadSection";
+import ProcessingQueue from "@/components/ProcessingQueue";
+import Sidebar from "@/components/Sidebar";
+import { Navigation } from "@/components/Navigation";
+
+export default function UploadPage() {
+  return (
+    <div className="flex h-screen overflow-hidden bg-slate-50">
+      <Sidebar />
+      <div className="flex-1 overflow-y-auto p-6 space-y-6">
+        <Navigation title="Upload Content" />
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <UploadSection />
+          <ProcessingQueue />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- allow flexible `apiRequest` argument order
- include YouTube option and allow any time when scheduling posts
- create Upload, Library and Accounts pages
- improve router and sidebar navigation

## Testing
- `npm run check` *(fails: Could not find type definitions and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_684cd7f6a7c883249d166b0405e3e27c